### PR TITLE
Location city bug fix

### DIFF
--- a/lib/geocoder/results/google_places_details.rb
+++ b/lib/geocoder/results/google_places_details.rb
@@ -116,6 +116,8 @@ module Geocoder::Result
         value = send(field)
         return value unless value.blank?
       end
+
+      nil
     end
 
     def state


### PR DESCRIPTION
If there’s no city associated with a google place id sent from checkout when creating a booking, the automated renter destination is sent as code to the owner. This is causing some owners to worry that the message is spam.

![Screenshot 2025-07-01 at 10 58 08 AM (2)](https://github.com/user-attachments/assets/5173b57e-35b1-40b2-8c56-edbc09ceb484)

More context: https://github.com/rvshare/rvshare-api/pull/5769
Regression Passed: https://jenkins-qa-ecs.rvshare.com/job/Regression/1319/ (in progress)